### PR TITLE
Fix example in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -164,7 +164,7 @@ const demo1 = async connection => {
     },
   })
 
-  const result = await connection.execute([me])
+  const result = await connection.execute(me)
   if (result.error) {
     console.error('oops', result)
   } else {


### PR DESCRIPTION
Copy-pasted some example code in the UCAN workshop. This fix made it work: the invocations are each individual arguments, not an array.

Wondering though if the array form would be more intuitive when batching multiple invocations - in the old docs it would be `connection.execute(invocations)`, in the working code it's `connection.execute(...invocations)`.