### PR TITLE
feat: define `resolveDIDKey` server option

### DIFF
--- a/packages/core/test/message.spec.js
+++ b/packages/core/test/message.spec.js
@@ -31,7 +31,7 @@ test('build message with an invocation', async () => {
   })
 
   const message = await Message.build({
-    invocations: [echo.invocation],
+    invocations: [echo.delegation],
   })
 
   assert.deepEqual(message.root.data, {

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -976,7 +976,7 @@ export interface HTTPError {
 /**
  * Options for UCAN validation.
  */
-export interface ValidatorOptions {
+export interface ValidatorOptions extends PrincipalResolver {
   /**
    * Takes principal parser that can be used to turn a `UCAN.Principal`
    * into `Ucanto.Principal`.


### PR DESCRIPTION
This was previously used if passed to the constructor but not defined in types.

resolves https://github.com/storacha/ucanto/issues/359