### PR TITLE
fix: infinite recursion with unknown attestation

### DIFF
--- a/packages/validator/src/lib.js
+++ b/packages/validator/src/lib.js
@@ -552,9 +552,13 @@ const verifySession = async (delegation, proofs, config) => {
 
   return await claim(
     attestation,
-    // We only consider attestations otherwise we will end up doing an
-    // exponential scan if there are other proofs that require attestations.
-    proofs.filter(isAttestation),
+    proofs
+      // We only consider attestations otherwise we will end up doing an
+      // exponential scan if there are other proofs that require attestations.
+      .filter(isAttestation)
+      // Also filter any proofs that _are_ the delegation we're verifying so
+      // we don't recurse indefinitely.
+      .filter(p => p.cid.toString() !== delegation.cid.toString()),
     config
   )
 }

--- a/packages/validator/test/session.spec.js
+++ b/packages/validator/test/session.spec.js
@@ -381,40 +381,6 @@ test('resolve key', async () => {
   })
 })
 
-test('aliased service', async () => {
-  const account = alice.withDID('did:mailto:web.mail:alice')
-  const alias = service.withDID('did:web:alias.storage')
-
-  const inv = echo.invoke({
-    audience: alias,
-    issuer: account,
-    with: account.did(),
-    nb: { message: 'hello world' },
-  })
-
-  const result = await access(await inv.delegate(), {
-    authority: w3,
-    capability: echo,
-    resolveDIDKey: _ => Schema.ok(alice.did()),
-    principal: Verifier,
-    validateAuthorization: () => ({ ok: {} }),
-  })
-
-  assert.containSubset(result, {
-    ok: {
-      match: {
-        value: {
-          can: 'debug/echo',
-          with: account.did(),
-          nb: {
-            message: 'hello world',
-          },
-        },
-      },
-    },
-  })
-})
-
 test('service can not delegate access to account', async () => {
   const account = Absentee.from({ id: 'did:mailto:web.mail:alice' })
   // service should not be able to delegate access to account resource


### PR DESCRIPTION
If proofs contain an attestation that is not issued by the service authority then `claim(...)` will recurse indefinitely.