### PR TITLE
feat: validate attestation from another service

### DIFF
--- a/packages/core/src/schema/schema.js
+++ b/packages/core/src/schema/schema.js
@@ -563,7 +563,7 @@ class Union extends API {
  * @param {U} variants
  * @returns {Schema.Schema<Schema.InferUnion<U>, I>}
  */
-const union = variants => new Union(variants)
+export const union = variants => new Union(variants)
 
 /**
  * @template T, U

--- a/packages/interface/src/capability.ts
+++ b/packages/interface/src/capability.ts
@@ -1,6 +1,7 @@
 import { Ability, Capability, DID, Link, Resource } from '@ipld/dag-ucan'
 import * as UCAN from '@ipld/dag-ucan'
 import {
+  AuthorityProver,
   Delegation,
   Result,
   Failure,
@@ -376,7 +377,8 @@ export interface ValidationOptions<
     PrincipalOptions,
     PrincipalResolver,
     ProofResolver,
-    RevocationChecker {
+    RevocationChecker,
+    Partial<AuthorityProver> {
   capability: CapabilityParser<Match<C, any>>
 }
 
@@ -386,7 +388,8 @@ export interface ClaimOptions
     PrincipalOptions,
     PrincipalResolver,
     ProofResolver,
-    RevocationChecker {}
+    RevocationChecker,
+    Partial<AuthorityProver> {}
 
 export interface DelegationError extends Failure {
   name: 'InvalidClaim'

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -976,7 +976,7 @@ export interface HTTPError {
 /**
  * Options for UCAN validation.
  */
-export interface ValidatorOptions extends PrincipalResolver {
+export interface ValidatorOptions extends PrincipalResolver, Partial<AuthorityProver> {
   /**
    * Takes principal parser that can be used to turn a `UCAN.Principal`
    * into `Ucanto.Principal`.
@@ -1086,6 +1086,16 @@ export interface PrincipalResolver {
   resolveDIDKey?: (
     did: UCAN.DID
   ) => Await<Result<DIDKey, DIDKeyResolutionError>>
+}
+
+/**
+ * `AuthorityProver` provides a set of proofs of authority.
+ */
+export interface AuthorityProver {
+  /**
+   * Proof(s) of authority.
+   */
+  proofs: Delegation[]
 }
 
 /**

--- a/packages/server/src/handler.js
+++ b/packages/server/src/handler.js
@@ -85,8 +85,7 @@ class InvalidAudience extends Failure {
    */
   constructor({ cause }) {
     super()
-    /** @type {'InvalidAudience'} */
-    this.name = 'InvalidAudience'
+    this.name = /** @type {const} */ ('InvalidAudience')
     this.cause = cause
   }
   describe() {

--- a/packages/validator/src/error.js
+++ b/packages/validator/src/error.js
@@ -334,8 +334,7 @@ export class Unauthorized extends Failure {
     failedProofs,
   }) {
     super()
-    /** @type {"Unauthorized"} */
-    this.name = 'Unauthorized'
+    this.name = /** @type {const} */  ('Unauthorized')
     this.capability = capability
     this.delegationErrors = delegationErrors
     this.unknownCapabilities = unknownCapabilities

--- a/packages/validator/src/lib.js
+++ b/packages/validator/src/lib.js
@@ -552,9 +552,13 @@ const verifySession = async (delegation, proofs, config) => {
 
   return await claim(
     attestation,
-    // We only consider attestations otherwise we will end up doing an
-    // exponential scan if there are other proofs that require attestations.
-    proofs.filter(isAttestation),
+    proofs
+      // We only consider attestations otherwise we will end up doing an
+      // exponential scan if there are other proofs that require attestations.
+      .filter(isAttestation)
+      // Also filter any proofs that _are_ the delegation we're verifying so
+      // we don't recurse indefinitely.
+      .filter(p => p.cid.toString() !== delegation.cid.toString()),
     config
   )
 }

--- a/packages/validator/test/session.spec.js
+++ b/packages/validator/test/session.spec.js
@@ -381,40 +381,6 @@ test('resolve key', async () => {
   })
 })
 
-test('aliased service', async () => {
-  const account = alice.withDID('did:mailto:web.mail:alice')
-  const alias = service.withDID('did:web:alias.storage')
-
-  const inv = echo.invoke({
-    audience: alias,
-    issuer: account,
-    with: account.did(),
-    nb: { message: 'hello world' },
-  })
-
-  const result = await access(await inv.delegate(), {
-    authority: w3,
-    capability: echo,
-    resolveDIDKey: _ => Schema.ok(alice.did()),
-    principal: Verifier,
-    validateAuthorization: () => ({ ok: {} }),
-  })
-
-  assert.containSubset(result, {
-    ok: {
-      match: {
-        value: {
-          can: 'debug/echo',
-          with: account.did(),
-          nb: {
-            message: 'hello world',
-          },
-        },
-      },
-    },
-  })
-})
-
 test('service can not delegate access to account', async () => {
   const account = Absentee.from({ id: 'did:mailto:web.mail:alice' })
   // service should not be able to delegate access to account resource


### PR DESCRIPTION
This PR implements #268 

Specifically, we are changing the `did:web:web3.storage` service DID to `did:web:up.storacha.network` and want to allow attestations issued by `did:web:web3.storage` to still be considered valid.

resolves #268 
closes #267 