### PR TITLE
feat: allow alternative audience for server

### DIFF
--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -45,6 +45,7 @@ import {
   Revoked,
   InferCapability,
   Authorization,
+  Reader
 } from './capability.js'
 import type * as Transport from './transport.js'
 import type { Tuple, Block } from './transport.js'
@@ -977,6 +978,12 @@ export interface HTTPError {
  * Options for UCAN validation.
  */
 export interface ValidatorOptions extends PrincipalResolver, Partial<AuthorityProver> {
+  /**
+   * Schema allowing invocations to be accepted for audiences other than the
+   * service itself.
+   */
+  readonly audience?: Reader<DID>
+
   /**
    * Takes principal parser that can be used to turn a `UCAN.Principal`
    * into `Ucanto.Principal`.

--- a/packages/server/src/handler.js
+++ b/packages/server/src/handler.js
@@ -52,7 +52,7 @@ export const provideAdvanced =
     // If audience schema is not provided we expect the audience to match
     // the server id. Users could pass `schema.string()` if they want to accept
     // any audience.
-    const audienceSchema = audience || Schema.literal(options.id.did())
+    const audienceSchema = audience || options.audience || Schema.literal(options.id.did())
     const result = audienceSchema.read(invocation.audience.did())
     if (result.error) {
       return { error: new InvalidAudience({ cause: result.error }) }

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -24,7 +24,7 @@ export const create = options => new Server(options)
  */
 class Server {
   /**
-   * @param {API.ServerOptions <S>} options
+   * @param {API.ServerOptions<S>} options
    */
   constructor({ id, service, codec, principal = Verifier, ...rest }) {
     const { catch: fail, ...context } = rest


### PR DESCRIPTION
This PR adds a new server option `audience`, which allows the server to accept invocations for audiences other than the service itself.

This option was already available (and continues to be available) on a per handler basis (via `provideAdvanced`), it takes precedence over the new global server audience.

Concretely, the DID for web3.storage is changing, but we want to be able to accept invocations targeting the old DID without having to configure every single handler.