### PR TITLE
fix: exported anonymous class type may not be private or protected

### DIFF
--- a/packages/core/src/schema/schema.js
+++ b/packages/core/src/schema/schema.js
@@ -16,7 +16,6 @@ export class API {
    * @param {Settings} settings
    */
   constructor(settings) {
-    /** @protected */
     this.settings = settings
   }
 


### PR DESCRIPTION
Fixes issue in newer typescript versions that is not ignorable or expect-error-able:

<img width="955" alt="Screenshot 2025-02-25 at 18 10 59" src="https://github.com/user-attachments/assets/db610bb4-8d99-45ad-8068-1936e850e205" />
