### PR TITLE
fix: Return 400 Bad Request for malformed payloads instead of handler execution error

### DIFF
--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -79,10 +79,18 @@ export const handle = async (server, request) => {
     }
   } else {
     const { encoder, decoder } = selection.ok
-    const message = await decoder.decode(request)
-    const result = await execute(message, server)
-    const response = await encoder.encode(result)
-    return response
+    try {
+      const message = await decoder.decode(request)
+      const result = await execute(message, server)
+      const response = await encoder.encode(result)
+      return response
+    } catch (error) {
+      return {
+        status: 400,
+        headers: { 'Content-Type': 'text/plain' },
+        body: new TextEncoder().encode(`Bad request: Malformed payload - ${error.message || 'Unable to decode request'}`),
+      }
+    }
   }
 }
 

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -84,7 +84,7 @@ export const handle = async (server, request) => {
       const result = await execute(message, server)
       const response = await encoder.encode(result)
       return response
-    } catch (/** @type {Error} */ err) {
+    } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unable to decode request'
       return {
         status: 400,

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -84,11 +84,12 @@ export const handle = async (server, request) => {
       const result = await execute(message, server)
       const response = await encoder.encode(result)
       return response
-    } catch (error) {
+    } catch (/** @type {Error} */ err) {
+      const errorMessage = err instanceof Error ? err.message : 'Unable to decode request'
       return {
         status: 400,
         headers: { 'Content-Type': 'text/plain' },
-        body: new TextEncoder().encode(`Bad request: Malformed payload - ${error.message || 'Unable to decode request'}`),
+        body: new TextEncoder().encode(`Bad request: Malformed payload - ${errorMessage}`),
       }
     }
   }

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -79,11 +79,9 @@ export const handle = async (server, request) => {
     }
   } else {
     const { encoder, decoder } = selection.ok
+    let message;
     try {
-      const message = await decoder.decode(request)
-      const result = await execute(message, server)
-      const response = await encoder.encode(result)
-      return response
+      message = await decoder.decode(request)
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unable to decode request'
       return {
@@ -92,6 +90,9 @@ export const handle = async (server, request) => {
         body: new TextEncoder().encode(`Bad request: Malformed payload - ${errorMessage}`),
       }
     }
+    const result = await execute(message, server)
+    const response = await encoder.encode(result)
+    return response
   }
 }
 


### PR DESCRIPTION
Currently, when a request has a malformed payload, the decoder throws an exception which is caught and returned as a handler execution error. This change improves error handling by specifically catching decoder exceptions and returning a proper HTTP 400 Bad Request response with a meaningful error message, making it clearer to clients that the issue is with their request format. Closes #358 