### PR TITLE
feat(transport): support custom headers in HTTP transport

### DIFF
--- a/packages/transport/src/http.js
+++ b/packages/transport/src/http.js
@@ -19,7 +19,7 @@ import * as API from '@ucanto/interface'
  * @param {URL} options.url
  * @param {(url:string, init:API.HTTPRequest) => API.Await<FetchResponse>} [options.fetch]
  * @param {string} [options.method]
- * @param {Headers | Map<string, string> | Record<string, string>} [options.headers]
+ * @param {Record<string, string>} [options.headers]
  * @returns {API.Channel<S>}
  */
 export const open = ({ url, method = 'POST', fetch, headers }) => {
@@ -46,7 +46,7 @@ class Channel {
    * @param {URL} options.url
    * @param {Fetcher} options.fetch
    * @param {string} [options.method]
-   * @param {Headers | Map<string, string> | Record<string, string> | {entries?: () => Iterable<[string, string]>}} [options.headers]
+   * @param {Record<string, string>} [options.headers]
    */
   constructor({ url, fetch, method, headers }) {
     this.fetch = fetch
@@ -60,18 +60,8 @@ class Channel {
    * @returns {Promise<API.HTTPResponse<API.AgentMessage<{ Out: API.InferReceipts<I, S>, In: API.Tuple<API.Invocation> }>>>}
    */
   async request({ headers, body }) {
-    const mergedHeaders = new Headers(headers)
-    if (this.headers && typeof this.headers.entries === 'function') {
-      for (const [key, value] of this.headers.entries()) {
-        // Only add headers from this.headers that don't exist in the request headers
-        if (!(key in mergedHeaders)) {
-          mergedHeaders.set(key, value)
-        }
-      }
-    }
-    
     const response = await this.fetch(this.url.href, {
-      headers: Object.fromEntries(mergedHeaders.entries()),
+      headers: { ...this.headers, ...headers },
       body,
       method: this.method,
     })

--- a/packages/transport/test/https.spec.js
+++ b/packages/transport/test/https.spec.js
@@ -82,3 +82,33 @@ if (typeof globalThis.fetch === 'undefined') {
     }
   })
 }
+
+test('headers from http channel are passed to fetch along with the request headers', async () => {
+  /** @type {Record<string, string>} */
+  let fetchedHeaders = {}
+
+  const channel = HTTP.open({
+    url: new URL('about:blank'),
+    fetch: async (url, init) => {
+      fetchedHeaders = init.headers
+      return {
+        ok: true,
+        arrayBuffer: () => UTF8.encode('pong').buffer,
+        headers: new Map([['content-type', 'text/plain']]),
+      }
+    },
+    headers: new Map([['x-client', 'abc']]),
+  })
+
+  const requestHeaders = { 'x-test': 'test-value', 'content-type': 'text/plain' }
+  
+  await channel.request({
+    headers: requestHeaders,
+    body: UTF8.encode('ping'),
+  })
+
+  // Verify the headers were merged and passed through
+  assert.equal(fetchedHeaders['x-test'], 'test-value')
+  assert.equal(fetchedHeaders['content-type'], 'text/plain')
+  assert.equal(fetchedHeaders['x-client'], 'abc')
+})

--- a/packages/transport/test/https.spec.js
+++ b/packages/transport/test/https.spec.js
@@ -97,7 +97,7 @@ test('headers from http channel are passed to fetch along with the request heade
         headers: new Map([['content-type', 'text/plain']]),
       }
     },
-    headers: new Map([['x-client', 'abc']]),
+    headers: { 'x-client': 'abc' },
   })
 
   const requestHeaders = { 'x-test': 'test-value', 'content-type': 'text/plain' }


### PR DESCRIPTION
### Changes
Added the ability to set default headers when creating HTTP channels that get merged with request headers. 

Request headers take precedence over channel headers.
This will allow us to pass custom headers to track which tool the agents are running (CLI, console, etc).

See: https://github.com/storacha/ai-integrations/issues/48