### PR TITLE
fix: allow session authorities as principals

### DIFF
--- a/packages/interface/src/capability.ts
+++ b/packages/interface/src/capability.ts
@@ -1,7 +1,7 @@
 import { Ability, Capability, DID, Link, Resource } from '@ipld/dag-ucan'
 import * as UCAN from '@ipld/dag-ucan'
 import {
-  AuthorityProver,
+  SessionAuthorizer,
   Delegation,
   Result,
   Failure,
@@ -378,7 +378,7 @@ export interface ValidationOptions<
     PrincipalResolver,
     ProofResolver,
     RevocationChecker,
-    Partial<AuthorityProver> {
+    Partial<SessionAuthorizer> {
   capability: CapabilityParser<Match<C, any>>
 }
 
@@ -389,7 +389,7 @@ export interface ClaimOptions
     PrincipalResolver,
     ProofResolver,
     RevocationChecker,
-    Partial<AuthorityProver> {}
+    Partial<SessionAuthorizer> {}
 
 export interface DelegationError extends Failure {
   name: 'InvalidClaim'

--- a/packages/interface/src/lib.ts
+++ b/packages/interface/src/lib.ts
@@ -978,7 +978,7 @@ export interface HTTPError {
 /**
  * Options for UCAN validation.
  */
-export interface ValidatorOptions extends PrincipalResolver, Partial<AuthorityProver> {
+export interface ValidatorOptions extends PrincipalResolver, Partial<SessionAuthorizer> {
   /**
    * Schema allowing invocations to be accepted for audiences other than the
    * service itself.
@@ -1097,13 +1097,16 @@ export interface PrincipalResolver {
 }
 
 /**
- * `AuthorityProver` provides a set of proofs of authority.
+ * `SessionAuthorizer` configures the means for authorizing a session.
  */
-export interface AuthorityProver {
+export interface SessionAuthorizer {
   /**
-   * Proof(s) of authority.
+   * Authorities we trust for session authorization. Note the authority for
+   * UCAN verification is implicitly trusted so need not be included here. This
+   * is typically used to provide additional authorities that are trusted to
+   * authorize a session.
    */
-  proofs: Delegation[]
+  sessionAuthorities: Principal[]
 }
 
 /**

--- a/packages/validator/src/lib.js
+++ b/packages/validator/src/lib.js
@@ -234,7 +234,7 @@ export const claim = async (
     resolveDIDKey = failDIDKeyResolution,
     canIssue = isSelfIssued,
     resolve = unavailable,
-    proofs: localProofs = [],
+    sessionAuthorities = [],
   }
 ) => {
   const config = {
@@ -245,7 +245,7 @@ export const claim = async (
     authority,
     validateAuthorization,
     resolveDIDKey,
-    proofs: localProofs,
+    sessionAuthorities,
   }
 
   const invalidProofs = []
@@ -569,13 +569,7 @@ const verifySignature = async (delegation, verifier) => {
  */
 const verifySession = async (delegation, proofs, config) => {
   // Recognize attestations from all authorized principals, not just authority
-  const withSchemas = config.proofs
-    .filter(
-      p =>
-        p.capabilities[0].can === 'ucan/attest' &&
-        p.capabilities[0].with === config.authority.did()
-    )
-    .map(p => Schema.literal(p.audience.did()))
+  const withSchemas = config.sessionAuthorities.map(a => Schema.literal(a.did()))
 
   const withSchema = withSchemas.length
     ? Schema.union([Schema.literal(config.authority.did()), ...withSchemas])

--- a/packages/validator/test/session.spec.js
+++ b/packages/validator/test/session.spec.js
@@ -126,13 +126,7 @@ test('validate mailto attested by another service', async () => {
       }
       return { error: new DIDKeyResolutionError(did) }
     },
-    proofs: [
-      await attest.delegate({
-        issuer: w3,
-        audience: other,
-        with: w3.did()
-      })
-    ],
+    sessionAuthorities: [other]
   })
 
   assert.containSubset(result, {
@@ -784,9 +778,6 @@ test('fail with multiple invalid verifiers', async () => {
       return { error: new DIDKeyResolutionError(did) }
     }
   })
-
-  console.log('Result:', result)
-  console.log('Result error:', result.error)
 
   assert.match(
     `${result.error}`,


### PR DESCRIPTION
In https://github.com/storacha/ucanto/pull/369 we introduced a change where authorities other than the service itself can issue attestations allowing validation to pass.

This was done by configuring the service with a delegation that authorizes the other authority to make attestations on it's behalf.

This works fine when the UCAN validation is being done by the authority the UCAN is being validated against, since the authority can just issue a delegation to the other authority. However in the case where the UCAN validation is being done by some other agent, it is not possible to provide a delegation and hence not possible to validate with alternate attestation authorities.

The storacha bluesky app validates UCANs against the storacha service authority (`did:web:up.storacha.network`) but because the bluesky service is not the storacha service it is unable to provide a delegation that authorizes `did:web:web3.storage` to make attestations on it's behalf. Hence a different approach is needed.